### PR TITLE
Add merge method

### DIFF
--- a/src/main/java/co/technove/air/AIR.java
+++ b/src/main/java/co/technove/air/AIR.java
@@ -280,4 +280,19 @@ public class AIR {
         ((Value) object).value = value;
     }
 
+    public void merge(AIR defaults){
+        for (final Map.Entry<String, Section> sections : defaults.sections.entrySet()) { // loop through default values
+            if (!this.sections.containsKey(sections.getKey())) { // missing an entire section, simply copy it over
+                this.sections.put(sections.getKey(), sections.getValue());
+            } else { // section exists, merge with defaults
+				for (final Map.Entry<String, Value<?>> values : sections.getValue().values.entrySet()) {
+					Section current = this.sections.get(sections.getKey());
+					if (!current.values.containsKey(values.getKey())) { // missing an individual value, copy it
+						current.values.put(values.getKey(), values.getValue());
+					}
+				}
+            }
+        }
+    }
+
 }

--- a/src/test/java/co/technove/air/AIRTest.java
+++ b/src/test/java/co/technove/air/AIRTest.java
@@ -30,7 +30,7 @@ public class AIRTest {
 	@Test
 	public void numericalParseTest() throws IOException {
 
-		final String contents = "# Hello, World\n" +
+		String contents = "# Hello, World\n" +
 								"[_head]\n" +
 								"\n" +
 								"[foo]\n" +
@@ -39,7 +39,7 @@ public class AIRTest {
 								"buq = -53\n" +
 								"qux = 12";
 
-		final AIR parser = new AIR(new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)));
+		AIR parser = new AIR(new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)));
 		Assertions.assertEquals(parser.getDouble("foo.bar", 0.0), -1.5);
 		Assertions.assertEquals(parser.getDouble("foo.baz", 0.0), 76.1);
 		Assertions.assertEquals(parser.getInt("foo.buq", 0), -53);
@@ -100,7 +100,7 @@ public class AIRTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         parser.save(outputStream);
-        String conf = outputStream.toString(StandardCharsets.UTF_8);
+        String conf = outputStream.toString(StandardCharsets.UTF_8.name());
 
         Assertions.assertEquals("[foo]\n  bar = \"hello\"\n\n", conf);
     }
@@ -121,7 +121,7 @@ public class AIRTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         parser.save(outputStream);
-        String out = outputStream.toString(StandardCharsets.UTF_8);
+        String out = outputStream.toString(StandardCharsets.UTF_8.name());
         Assertions.assertEquals(out, "[lists]\n" +
           "  list1 = [\n" +
           "    \"foo\",\n" +
@@ -151,4 +151,26 @@ public class AIRTest {
           "  ]\n" +
           "\n");
     }
+
+	@Test
+	public void mergeTest() throws IOException {
+		String defaults = "[foo]\n" +
+						  "bar = \"qux\"\n" +
+						  "baz = 15\n" +
+						  "[qaz]\n" +
+						  "bat = false";
+
+		String contents = "[foo]\n" +
+						  "baz = 2\n";
+
+		AIR defaultsParser = new AIR(new ByteArrayInputStream(defaults.getBytes(StandardCharsets.UTF_8)));
+		AIR contentsParser = new AIR(new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)));
+
+		contentsParser.merge(defaultsParser);
+
+		Assertions.assertEquals(contentsParser.getString("foo.bar", null), "qux");
+		Assertions.assertEquals(contentsParser.getInt("foo.baz", 0), 2);
+		Assertions.assertFalse(contentsParser.getBoolean("qaz.bat", true));
+		Assertions.assertEquals(contentsParser.getString("foo.qux", "nonexistent"), "nonexistent");
+	}
 }


### PR DESCRIPTION
Add merge method, which merges two AIR instances, filling in values that exist in the given parser but not in the current parser into the current parser. Useful if you have a default configuration and want to ensure that users always have every value present within the modified configuration. 